### PR TITLE
Adjust build output and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: dir docs

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 .env
 node_modules
 dist
+docs
 dist-ssr
 *.local
 

--- a/README.en.md
+++ b/README.en.md
@@ -22,7 +22,7 @@ This project demonstrates a small chat interface built with [Vue 3](https://vuej
 ## Useful Commands
 
 - `yarn dev` — starts the Vite development server.
-- `yarn build` — generates the production build in `dist/`.
+- `yarn build` — generates the production build in `docs/`.
 - `yarn preview` — serves the production build for local testing.
 - `yarn lint` — runs ESLint (if necessary, set `NODE_ENV=development`).
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project demonstrates a small chat interface built with [Vue 3](https://vuej
 ## Useful Commands
 
 - `yarn dev` — starts the Vite development server.
-- `yarn build` — generates the production build in `dist/`.
+- `yarn build` — generates the production build in `docs/`.
 - `yarn preview` — serves the production build for local testing.
 - `yarn lint` — runs ESLint (if necessary, set `NODE_ENV=development`).
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,11 @@ import vueDevTools from 'vite-plugin-vue-devtools';
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: './',
+  build: {
+    outDir: 'docs',
+    emptyOutDir: true,
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- output compiled files to the `docs` folder instead of `dist`
- update documentation to mention the new build location
- add a GitHub Actions workflow running `yarn build`

## Testing
- `yarn install`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68628028a938832990ff9e29271bb3b1