### PR TITLE
Fix CI push permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- allow docs deploy job to push back to repo with default GITHUB_TOKEN

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6862934ae4e88329879f31220d9f1e66