### PR TITLE
Use process.env NODE_ENV for lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This project demonstrates a small chat interface built with [Vue 3](https://vuejs.org/), [TypeScript](https://www.typescriptlang.org/) and [Vite](https://vitejs.dev/). The application simulates a simple conversation between the user and an agent, including support for audio messages.
 
+If you'd like to see the chat in action without downloading the code, check the live preview at [https://douglasjordao.github.io/simple-webchat/](https://douglasjordao.github.io/simple-webchat/).
+
 ## Features
 
 - Displays messages preloaded from `public/mocks/messages.json`.
@@ -26,7 +28,7 @@ This project demonstrates a small chat interface built with [Vue 3](https://vuej
 - `yarn dev` — starts the Vite development server.
 - `yarn build` — generates the production build in `docs/`.
 - `yarn preview` — serves the production build for local testing.
-- `yarn lint` — runs ESLint (if necessary, set `NODE_ENV=development`).
+- `yarn lint` — runs ESLint.
 
 ## Structure
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -2,6 +2,8 @@
 
 Este projeto demonstra uma pequena interface de chat construída com [Vue 3](https://vuejs.org/), [TypeScript](https://www.typescriptlang.org/) e [Vite](https://vitejs.dev/). A aplicação simula uma conversa simples entre o usuário e um agente, incluindo suporte a mensagens de áudio.
 
+Se preferir apenas testar rapidamente, veja uma prévia do webchat em [https://douglasjordao.github.io/simple-webchat/](https://douglasjordao.github.io/simple-webchat/).
+
 ## Funcionalidades
 
 - Listagem de mensagens pré-carregadas a partir de `public/mocks/messages.json`;
@@ -24,7 +26,7 @@ Este projeto demonstra uma pequena interface de chat construída com [Vue 3](htt
 - `yarn dev` &mdash; inicia o servidor de desenvolvimento do Vite.
 - `yarn build` &mdash; gera a versão de produção em `dist/`.
 - `yarn preview` &mdash; serve a build de produção para testes locais.
-- `yarn lint` &mdash; executa o ESLint (caso necessário, defina `NODE_ENV=development`).
+- `yarn lint` &mdash; executa o ESLint.
 
 ## Estrutura
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,8 +25,8 @@ export default defineConfig([
       'vue/multi-word-component-names': 'off',
       'vue/no-v-html': 'off',
       'no-debugger':
-        import.meta.env.NODE_ENV === 'production' ? 'error' : 'off',
-      'no-console': import.meta.env.NODE_ENV === 'production' ? 'error' : 'off',
+        process.env.NODE_ENV === 'production' ? 'error' : 'off',
+      'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     },
   },
 ]);


### PR DESCRIPTION
## Summary
- fix environment check in `eslint.config.js`
- update README docs for lint command

## Testing
- `NODE_ENV=development yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686295b522048329acb78b6db3159fa9